### PR TITLE
Added Analytics and RemoveOnUnpin conviguration variables.

### DIFF
--- a/experiments.go
+++ b/experiments.go
@@ -11,4 +11,6 @@ type Experiments struct {
 	StrategicProviding   bool
 	StorageHostEnabled   bool
 	StorageClientEnabled bool
+	Analytics            bool
+	RemoveOnUnpin        bool
 }

--- a/init.go
+++ b/init.go
@@ -12,7 +12,7 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-func Init(out io.Writer, nBitsForKeypair int, keyType string, importKey string) (*Config, error) {
+func Init(out io.Writer, nBitsForKeypair int, keyType string, importKey string, rmOnUnpin bool) (*Config, error) {
 	identity, err := identityConfig(out, nBitsForKeypair, keyType, importKey)
 	if err != nil {
 		return nil, err
@@ -81,6 +81,9 @@ func Init(out io.Writer, nBitsForKeypair int, keyType string, importKey string) 
 				GracePeriod: DefaultConnMgrGracePeriod.String(),
 				Type:        "basic",
 			},
+		},
+		Experimental: Experiments{
+			RemoveOnUnpin: rmOnUnpin,
 		},
 	}
 


### PR DESCRIPTION
This PR introduces two new configuration variables.

Experimental.Analytics: Analytics variable is used to opt-in/out of analytic data collection. By default it's set to "false."

Experimental.RemoveOnUnpin: RemoveOnUnpin triggers removal of a file from a local node, when the file is unpinned. By default it's set to "false."