### PR TITLE
BTFSINFRA-527 set keyType value in the default case

### DIFF
--- a/init.go
+++ b/init.go
@@ -180,6 +180,7 @@ func identityConfig(out io.Writer, nbits int, keyType string, importKey string) 
 			key = ci.ECDSA
 		default:
 			key = ci.Secp256k1
+			keyType = "Secp256k1"
 		}
 
 		fmt.Fprintf(out, "generating %v-bit %s keypair...", nbits, keyType)


### PR DESCRIPTION
when performing a `daemon init` with default settings, the keyType value that is passed from go-btfs:doInit is empty.  therefore if we wish to print out the keytype out to the screen with the default settings, we need to set the keyType to "Secp256k1" otherwise it shows blank.