### PR TITLE
Enable libp2p streaming flag by default (for remote api)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multiaddr-dns v0.0.2
 )
+
+go 1.13

--- a/init.go
+++ b/init.go
@@ -84,9 +84,10 @@ func Init(out io.Writer, nBitsForKeypair int, keyType string, importKey string, 
 			},
 		},
 		Experimental: Experiments{
-			RemoveOnUnpin:    rmOnUnpin,
-			HostsSyncEnabled: DefaultHostsSyncEnabled,
-			HostsSyncMode:    DefaultHostsSyncMode,
+			Libp2pStreamMounting: true, // Enabled for remote api
+			RemoveOnUnpin:        rmOnUnpin,
+			HostsSyncEnabled:     DefaultHostsSyncEnabled,
+			HostsSyncMode:        DefaultHostsSyncMode,
 		},
 	}
 


### PR DESCRIPTION
Now it should work (tested locally) for new installs

```
eric@ETCTMBP ~/go/src/github.com/tron-us/go-btfs $ BTFS_PATH=~/.btfs3 btfs init
initializing BTFS node at /Users/eric/.btfs3
generating 2048-bit Secp256k1 keypair...done
peer identity: 16Uiu2HAkuyS4Dc1a3EScu3KHyjSyNiWrBVAPcnKkXwXmg6A5UVnN
to get started, enter:

	btfs cat /btfs/QmZjrLVdUpqVU6Pnc8pBnyQxVdpn9J8tfcsycP84W6N93C/readme

eric@ETCTMBP ~/go/src/github.com/tron-us/go-btfs $ BTFS_PATH=~/.btfs3 btfs daemon
Initializing daemon...
go-btfs version: 0.2.2-27e7fce83-dirty
Repo version: 7
System version: amd64/darwin
Golang version: go1.13.4
Swarm listening on /ip4/10.10.0.23/tcp/4001
Swarm listening on /ip4/127.0.0.1/tcp/4001
Swarm listening on /ip4/127.94.0.1/tcp/4001
Swarm listening on /ip4/192.168.101.245/tcp/4001
Swarm listening on /ip6/::1/tcp/4001
Swarm listening on /p2p-circuit
Swarm announcing /ip4/38.142.72.82/tcp/4001
API server listening on /ip4/127.0.0.1/tcp/5001
WebUI: http://127.0.0.1:5001/webui
Gateway (readonly) server listening on /ip4/127.0.0.1/tcp/8080
Remote API server listening on /ip4/127.0.0.1/tcp/5101
Daemon is ready
```