### PR TITLE
BTFS-1209 BTFS-906: Bump host max storage from 10GB to 1TB

### DIFF
--- a/init.go
+++ b/init.go
@@ -172,8 +172,20 @@ func DefaultServicesConfig() Services {
 		HubDomain:          "https://hub.btfs.io",
 		EscrowDomain:       "https://escrow.btfs.io",
 		GuardDomain:        "https://guard.btfs.io",
-		EscrowPubKeys:      []string{}, // TODO: TBD
-		GuardPubKeys:       []string{}, // TODO: TBD
+		EscrowPubKeys:      []string{"CAISIQPAfB2Mt2ic+n3JcL4vrKXxBCmB0iNh+5BYiXdJNWed/Q=="},
+		GuardPubKeys:       []string{"CAISIQJ16EiwvGko4SaBEEUFyMdNZp1vKsTLgIXCY6fRa3/Obg=="},
+	}
+}
+
+// DefaultServicesConfigDev returns the default set of configs for dev external services.
+func DefaultServicesConfigDev() Services {
+	return Services{
+		StatusServerDomain: "https://status-dev.btfs.io",
+		HubDomain:          "https://hub-dev.btfs.io",
+		EscrowDomain:       "https://escrow-dev.btfs.io",
+		GuardDomain:        "https://guard-dev.btfs.io",
+		EscrowPubKeys:      []string{"CAISIQJOcRK0q4TOwpswAkvMMq33ksQfhplEyhHcZnEUFbthQg=="},
+		GuardPubKeys:       []string{"CAISIQJhPBQWKPPjYcuPWR9sl+QlN0wJSRbQs3yUKmggvubXwg=="},
 	}
 }
 

--- a/profile.go
+++ b/profile.go
@@ -224,8 +224,29 @@ fetching may be degraded.
 		Transform: func(c *Config) error {
 			c.Experimental.Libp2pStreamMounting = true
 			c.Experimental.StorageHostEnabled = true
-			c.Addresses.RemoteAPI = Strings{"/ip4/0.0.0.0/tcp/5101"}
-			// TODO: Set host-specific values
+			if len(c.Addresses.RemoteAPI) == 0 {
+				c.Addresses.RemoteAPI = Strings{"/ip4/0.0.0.0/tcp/5101"}
+			}
+			if c.Datastore.StorageMax == "10GB" {
+				c.Datastore.StorageMax = "1TB"
+			}
+			c.Services = DefaultServicesConfig()
+			return nil
+		},
+	},
+	"storage-host-dev": {
+		Description: `[dev] Configures necessary flags and options for node to become a storage host.`,
+
+		Transform: func(c *Config) error {
+			c.Experimental.Libp2pStreamMounting = true
+			c.Experimental.StorageHostEnabled = true
+			if len(c.Addresses.RemoteAPI) == 0 {
+				c.Addresses.RemoteAPI = Strings{"/ip4/0.0.0.0/tcp/5101"}
+			}
+			if c.Datastore.StorageMax == "10GB" {
+				c.Datastore.StorageMax = "1TB"
+			}
+			c.Services = DefaultServicesConfigDev()
 			return nil
 		},
 	},
@@ -237,8 +258,25 @@ fetching may be degraded.
 			c.Experimental.StorageClientEnabled = true
 			c.Experimental.HostsSyncEnabled = true
 			c.Experimental.HostsSyncMode = DefaultHostsSyncMode
-			c.Addresses.RemoteAPI = Strings{"/ip4/0.0.0.0/tcp/5101"}
-			// TODO: Set client-specific values
+			if len(c.Addresses.RemoteAPI) == 0 {
+				c.Addresses.RemoteAPI = Strings{"/ip4/0.0.0.0/tcp/5101"}
+			}
+			c.Services = DefaultServicesConfig()
+			return nil
+		},
+	},
+	"storage-client-dev": {
+		Description: `[dev] Configures necessary flags and options for node to pay to store files on the network.`,
+
+		Transform: func(c *Config) error {
+			c.Experimental.Libp2pStreamMounting = true
+			c.Experimental.StorageClientEnabled = true
+			c.Experimental.HostsSyncEnabled = true
+			c.Experimental.HostsSyncMode = DefaultHostsSyncMode
+			if len(c.Addresses.RemoteAPI) == 0 {
+				c.Addresses.RemoteAPI = Strings{"/ip4/0.0.0.0/tcp/5101"}
+			}
+			c.Services = DefaultServicesConfigDev()
 			return nil
 		},
 	},


### PR DESCRIPTION
Also add new profiles storage-host-dev and storage-client-dev to switch
to the correct service urls and pub keys.