### PR TITLE
Enable migrations for host and renter settings

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -23,11 +23,28 @@ func migrate_2_StatusUrl(cfg *Config) bool {
 	return false
 }
 
+func migrate_3_StorageSettings(cfg *Config, fromV0 bool) bool {
+	// 1) Enable host if user opted in (analytics = true) AND
+	// it is a new upgrade from 0.x.x version
+	// 2) Enable renter if it is a new upgrade from 0.x.x version
+	if !fromV0 {
+		return false
+	}
+	// no error possible
+	Profiles["storage-client"].Transform(cfg)
+	if cfg.Experimental.Analytics {
+		Profiles["storage-host"].Transform(cfg)
+	}
+	return true
+}
+
 // MigrateConfig migrates config options to the latest known version
 // It may correct incompatible configs as well
 func MigrateConfig(cfg *Config) bool {
 	updated := false
-	updated = migrate_1_Services(cfg) || updated
+	upToV1 := migrate_1_Services(cfg)
+	updated = upToV1 || updated
 	updated = migrate_2_StatusUrl(cfg) || updated
+	updated = migrate_3_StorageSettings(cfg, upToV1) || updated
 	return updated
 }

--- a/profile.go
+++ b/profile.go
@@ -224,6 +224,7 @@ fetching may be degraded.
 		Transform: func(c *Config) error {
 			c.Experimental.Libp2pStreamMounting = true
 			c.Experimental.StorageHostEnabled = true
+			c.Experimental.Analytics = true
 			if len(c.Addresses.RemoteAPI) == 0 {
 				c.Addresses.RemoteAPI = Strings{"/ip4/0.0.0.0/tcp/5101"}
 			}
@@ -240,6 +241,7 @@ fetching may be degraded.
 		Transform: func(c *Config) error {
 			c.Experimental.Libp2pStreamMounting = true
 			c.Experimental.StorageHostEnabled = true
+			c.Experimental.Analytics = true
 			if len(c.Addresses.RemoteAPI) == 0 {
 				c.Addresses.RemoteAPI = Strings{"/ip4/0.0.0.0/tcp/5101"}
 			}


### PR DESCRIPTION
1) If upgrading from v0, enable renter by default.
2) If upgrading from v0, enable host if analytics = true (opted in).